### PR TITLE
Remove echo=True

### DIFF
--- a/pyramid_georest/lib/database.py
+++ b/pyramid_georest/lib/database.py
@@ -36,7 +36,7 @@ class Connection:
         """
         self.url = url
         if 'cx_oracle' in self.url:
-            self.engine = create_engine(self.url, echo=True, pool_size=1, coerce_to_unicode=True)
+            self.engine = create_engine(self.url, pool_size=1, coerce_to_unicode=True)
         else:
-            self.engine = create_engine(self.url, echo=True, pool_size=1)
+            self.engine = create_engine(self.url, pool_size=1)
         self.session = scoped_session(sessionmaker(bind=self.engine, extension=ZopeTransactionExtension()))


### PR DESCRIPTION
Remove `echo=True` to prevent the application's logging configuration from being overwritten.